### PR TITLE
telegraf.service remove curly brackets on $TELEGRAF_OPTS

### DIFF
--- a/scripts/telegraf.service
+++ b/scripts/telegraf.service
@@ -6,7 +6,7 @@ After=network.target
 [Service]
 EnvironmentFile=-/etc/default/telegraf
 User=telegraf
-ExecStart=/usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory /etc/telegraf/telegraf.d ${TELEGRAF_OPTS}
+ExecStart=/usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory /etc/telegraf/telegraf.d $TELEGRAF_OPTS
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 RestartForceExitStatus=SIGPIPE


### PR DESCRIPTION
With the brackets you cannot add more than 1 flag to the ExecStart command. Flags that require arguments will not work.

The following addition to /etc/default/telegraf gives a "flag provided but not defined" ERROR and the service fails to start. Removing the brackets from $TELEGRAF_OPTS fixes this. 

`#/etc/default/telegraf`
`TELEGRAF_OPTS=-pidfile /var/run/telegraf/telegraf.pid`

log: flag provided but not defined: -pidfile /var/run/telegraf/telegraf.pid

[ https://www.freedesktop.org/software/systemd/man/systemd.service.html](url)
"Use "${FOO}" as part of a word, or as a word of its own, on the command line, in which case it will be replaced by the value of the environment variable including all whitespace it contains, resulting in a single argument. Use "$FOO" as a separate word on the command line, in which case it will be replaced by the value of the environment variable split at whitespace, resulting in zero or more arguments. "



